### PR TITLE
new build option USE_QT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,10 +12,26 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include(GNUInstallDirs)
 
-find_package(QT NAMES Qt5 Qt6 REQUIRED)
+option(USE_QT "Choose which Qt major version (5 or 6) to prefer. By default uses whatever is found")
+
+if (USE_QT)
+    if (NOT (USE_QT EQUAL 5 OR USE_QT EQUAL 6))
+        message(FATAL_ERROR "Wrong Qt major version. Only 5 and 6 are valid options")
+    endif()
+endif()
+
+if (USE_QT EQUAL 5)
+    find_package(QT NAMES Qt5 REQUIRED)
+elseif (USE_QT EQUAL 6)
+    find_package(QT NAMES Qt6 REQUIRED)
+else()
+    find_package(QT NAMES Qt5 Qt6 REQUIRED)
+endif()
+
 if ((CMAKE_SYSTEM_NAME MATCHES "Linux") AND (QT_VERSION_MAJOR EQUAL 6) AND (QT_VERSION VERSION_LESS 6.4))
     message(WARNING "Unsupported Qt version ${QT_VERSION} for ${CMAKE_SYSTEM_NAME}")
 endif()
+
 find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Gui Widgets Multimedia REQUIRED)
 find_package(Drumstick 2.6 COMPONENTS RT Widgets REQUIRED)
 


### PR DESCRIPTION
This PR ports https://github.com/pedrolcl/Linux-SonivoxEas/commit/e464a27c0bee6c59c0b8fff1d3cc9c9341214051 from Linux-SonivoxEas to multiplatform-sonivoxeas.

Some background: I created an Arch Linux package for multiplatform-sonivoxeas (https://aur.archlinux.org/packages/mp-sonivoxeas) and I need to restrict the build to Qt6 because drumstick is linked against Qt6 on Arch Linux and linking against both, Qt5 and Qt6, causes crashes.

(cherry picked from Linux-SonivoxEas commit e464a27c0bee6c59c0b8fff1d3cc9c9341214051)
Merged-by: Michael Lass <bevan@bi-co.net>