### PR TITLE
guisynth: add StartupWMClass to desktop file

### DIFF
--- a/guisynth/mp_guisynth.desktop
+++ b/guisynth/mp_guisynth.desktop
@@ -9,3 +9,4 @@ Categories=AudioVideo;Audio;Midi;
 Keywords=Music;Midi;Player;
 MimeType=audio/midi;audio/x-midi;
 Comment=SonivoxEas MIDI Synth
+StartupWMClass=mp_GUISynth


### PR DESCRIPTION
Window managers recognize running applications by their name and mp_guisynth.desktop needs to be connected to the application name mp_GUISynth.

Otherwise, e.g. in Gnome Shell, the running application will have a generic icon and will be named "mp_GUISynth" instead of "SonivoxEAS Midi Synth".